### PR TITLE
Nix darwin with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.ONESHELL:
+.SHELL := /usr/bin/bash
+
+help: ## display task help output
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+deploy: ## Build and switch to new nix darwin environment
+	nix build .#darwinConfigurations.bluestreak.system \
+	   --extra-experimental-features 'nix-command flakes'
+
+	./result/sw/bin/darwin-rebuild switch --flake .#bluestreak

--- a/darwin/bluestreak/configuration.nix
+++ b/darwin/bluestreak/configuration.nix
@@ -10,6 +10,36 @@
     inputs.home-manager.darwinModules.home-manager
   ];
 
+  nixpkgs = {
+    hostPlatform = lib.mkDefault "aarch64-darwin";
+    config = {
+      allowUnfree = lib.mkDefault true;
+      allowUnfreePredicate = lib.mkDefault true;
+    };
+  };
+
+  nix = {
+    settings = {
+      # enable flakes + nix
+      experimental-features = "nix-command flakes";
+      auto-optimise-store = true;
+      trusted-users = ["root" "sme"];
+
+      # Binary cache setup
+      # Run "cachix use <repo>" take values from ~/.config/nix/nix.conf
+      # Then remove generated conf file
+      substituters = ["https://nix-community.cachix.org" "https://cache.nixos.org"];
+      trusted-public-keys = [
+        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      ];
+    };
+  };
+
+  # home.shellAliases = {
+  #   yay = "sudo darwin-rebuild switch --flake .#bluestreak";
+  # };
+
   home-manager = {
     useGlobalPkgs = true;
     useUserPackages = true;

--- a/darwin/bluestreak/configuration.nix
+++ b/darwin/bluestreak/configuration.nix
@@ -40,9 +40,18 @@
   #   yay = "sudo darwin-rebuild switch --flake .#bluestreak";
   # };
 
+  # Avoids:
+  # Error: HOME is set to "/Users/sme" but we expect "/var/empty"
+  users.users.sme.home = "/Users/sme";
+  users.users.sme.name = "sme";
+
   home-manager = {
     useGlobalPkgs = true;
     useUserPackages = true;
-    users.sme = import ../../home/sme/bluestreak.nix;
+    users.sme.imports = [../../home/sme/bluestreak.nix];
   };
+
+  # Avoids:
+  # error: The daemon is not enabled but this is a multi-user install, aborting activation
+  services.nix-daemon.enable = true;
 }

--- a/darwin/bluestreak/configuration.nix
+++ b/darwin/bluestreak/configuration.nix
@@ -1,0 +1,18 @@
+{
+  inputs,
+  outputs,
+  lib,
+  config,
+  pkgs,
+  ...
+}: {
+  imports = [
+    inputs.home-manager.darwinModules.home-manager
+  ];
+
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    users.sme = import ../../home/sme/bluestreak.nix;
+  };
+}

--- a/darwin/bluestreak/default.nix
+++ b/darwin/bluestreak/default.nix
@@ -1,0 +1,7 @@
+{
+  pkgs,
+  inputs,
+  ...
+}: {
+  imports = [./configuration.nix];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719128254,
+        "narHash": "sha256-I7jMpq0CAOZA/i70+HDQO/ulLttyQu/K70cSESiMX7A=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "50581970f37f06a4719001735828519925ef8310",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "emacs-overlay": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -113,27 +134,6 @@
         "type": "github"
       }
     },
-    "nix-darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1718662658,
-        "narHash": "sha256-AKG7BsqtVWDlefgzyKz7vjaKTLi4+bmTSBhowbQoZtM=",
-        "owner": "LnL7",
-        "repo": "nix-darwin",
-        "rev": "29b3096a6e283d7e6779187244cb2a3942239fdf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "LnL7",
-        "ref": "master",
-        "repo": "nix-darwin",
-        "type": "github"
-      }
-    },
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -204,10 +204,10 @@
     },
     "root": {
       "inputs": {
+        "darwin": "darwin",
         "emacs-overlay": "emacs-overlay",
         "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
-        "nix-darwin": "nix-darwin",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
     nixos-wsl.url = "github:nix-community/NixOS-WSL";
 
     # nix-darwin
-    nix-darwin.url = "github:LnL7/nix-darwin/master";
-    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+    darwin.url = "github:LnL7/nix-darwin/master";
+    darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     # emacs overlay
     emacs-overlay.url = "github:nix-community/emacs-overlay";
@@ -31,7 +31,7 @@
     self,
     nixpkgs,
     home-manager,
-    nix-darwin,
+    darwin,
     ...
   } @ inputs: let
     inherit (self) outputs;
@@ -40,6 +40,11 @@
 
     mkNixos = modules:
       nixpkgs.lib.nixosSystem {
+        inherit modules;
+        specialArgs = {inherit inputs outputs;};
+      };
+    mkDarwin = modules:
+      darwin.lib.darwinSystem {
         inherit modules;
         specialArgs = {inherit inputs outputs;};
       };
@@ -70,6 +75,9 @@
     # NixOS entrypoint
     # Use:'nixos-rebuild --flake .#hostname'
     nixosConfigurations = {galvatron = mkNixos [./hosts/galvatron-wsl];};
+
+    # darwin-rebuild --flake .#hostname
+    darwinConfigurations = {bluestreak = mkDarwin [./darwin/bluestreak];};
 
     # Standalone home-manager entrypoints
     # Use: 'home-manager --flake .#username@your-hostname'

--- a/home/sme/bluestreak.nix
+++ b/home/sme/bluestreak.nix
@@ -24,8 +24,7 @@ in {
   # You can import other home-manager modules here
   imports = [
     # If you want to use home-manager modules from other flakes (such as nix-colors):
-    # inputs.nix-colors.homeManagerModule
-
+    # inputs.home-manager.darwinModules.home-manager
     # Lots of duplication in current config, but global isn't truly global or safe to use cross platform for now
     # ./global/default.nix
   ];
@@ -60,7 +59,7 @@ in {
 
   home = {
     username = "sme";
-    homeDirectory = lib.mkDefault "/Users/sme";
+    # homeDirectory = lib.mkDefault "/Users/sme";
     stateVersion = "24.05";
     # should be macOS specific packages as needed
     # but right now is duplicating everything from global because global is busted cross platform

--- a/home/sme/bluestreak.nix
+++ b/home/sme/bluestreak.nix
@@ -38,29 +38,29 @@ in {
     };
   };
 
-  nixpkgs = {
-    # You can add overlays here
-    overlays = [
-      # If you want to use overlays exported from other flakes:
-      # neovim-nightly-overlay.overlays.default
+  # nixpkgs = {
+  #   # You can add overlays here
+  #   overlays = [
+  #     # If you want to use overlays exported from other flakes:
+  #     # neovim-nightly-overlay.overlays.default
 
-      # Or define it inline, for example:
-      # (final: prev: {
-      #   hi = final.hello.overrideAttrs (oldAttrs: {
-      #     patches = [ ./change-hello-to-hi.patch ];
-      #   });
-      # })
-    ];
-    config = {
-      allowUnfree = true;
-      # Workaround for https://github.com/nix-community/home-manager/issues/2942
-      allowUnfreePredicate = _: true;
-    };
-  };
+  #     # Or define it inline, for example:
+  #     # (final: prev: {
+  #     #   hi = final.hello.overrideAttrs (oldAttrs: {
+  #     #     patches = [ ./change-hello-to-hi.patch ];
+  #     #   });
+  #     # })
+  #   ];
+  #   config = {
+  #     allowUnfree = true;
+  #     # Workaround for https://github.com/nix-community/home-manager/issues/2942
+  #     allowUnfreePredicate = _: true;
+  #   };
+  # };
 
   home = {
     username = "sme";
-    homeDirectory = "/Users/sme";
+    homeDirectory = lib.mkDefault "/Users/sme";
     stateVersion = "24.05";
     # should be macOS specific packages as needed
     # but right now is duplicating everything from global because global is busted cross platform
@@ -105,7 +105,7 @@ in {
       tflint
       tflint-ruleset-aws
       tfsec
-      urlscan
+      # urlscan
       wget
       unzip
       vault
@@ -215,7 +215,8 @@ in {
 
     #  export TERM=xterm-24bit
     envExtra = ''
-      export ZSH_AUTOSUGGEST_USE_ASYNC=true;
+      export ZSH_AUTOSUGGEST_USE_ASYNC=true
+      export PATH="/opt/homebrew/bin:$PATH"
     '';
 
     initExtra = builtins.readFile ./global/includes/zshrc;


### PR DESCRIPTION
This does not work as is.

It will build and apply, but it is ignoring home-manager packages for some unknown reason.

Current output
```
❯ make deploy
nix build .#darwinConfigurations.bluestreak.system \
           --extra-experimental-features 'nix-command flakes'
./result/sw/bin/darwin-rebuild switch --flake .#bluestreak
building the system configuration...
user defaults...
setting up user launchd services...
setting up /Applications/Nix Apps...
setting up pam...
applying patches...
setting up /etc...
system defaults...
setting up launchd services...
reloading nix-daemon...
waiting for nix-daemon
configuring networking...
setting up /Library/Fonts/Nix Fonts...
setting nvram variables...
Activating home-manager configuration for sme
Starting Home Manager activation
Activating checkFilesChanged
Activating checkLaunchAgents
Activating checkLinkTargets
Activating writeBoundary
Activating createGpgHomedir
Activating linkGeneration
Cleaning up orphan links from /Users/sme
No change so reusing latest profile generation 26
Creating home file links in /Users/sme
Activating batCache
No themes were found in '/Users/sme/.config/bat/themes', using the default set
No syntaxes were found in '/Users/sme/.config/bat/syntaxes', using the default set.
Writing theme set to /Users/sme/.cache/bat/themes.bin ... okay
Writing syntax set to /Users/sme/.cache/bat/syntaxes.bin ... okay
Writing metadata to folder /Users/sme/.cache/bat ... okay
Activating installPackages
Activating onFilesChange
Activating setupLaunchAgents
```